### PR TITLE
Switch to uWSGI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get -y install apt-transport-https\
                        lsb-release\
                        python-dev\
                        python-pip\
-                       python-psycopg2
+                       python-psycopg2\
+                       uwsgi\
+                       uwsgi-plugin-python
 
 RUN curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN VERSION=node_8.x && \
@@ -35,6 +37,9 @@ RUN pip install /tmp/timesketch/
 
 # Copy the Timesketch configuration file into /etc
 RUN cp /usr/local/share/timesketch/timesketch.conf /etc
+
+# Copy the TimeSketch uWSGI configuration file into the container
+COPY uwsgi_config.ini /
 
 # Copy the entrypoint script into the container
 COPY docker-entrypoint.sh /

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,4 +15,4 @@ tsctl add_user -u "$TIMESKETCH_USER" -p "$TIMESKETCH_PASSWORD"
 
 # Run the Timesketch server (without SSL)
 exec `bash -c "/usr/local/bin/celery -A timesketch.lib.tasks worker --uid nobody --loglevel info &\
-gunicorn -b 0.0.0.0:5000 --access-logfile - --error-logfile - --log-level info --timeout 600 timesketch.wsgi:application"`
+ uwsgi --ini timesketch_config.ini"`

--- a/uwsgi_config.ini
+++ b/uwsgi_config.ini
@@ -1,0 +1,17 @@
+[uwsgi]
+plugin = python
+chdir = /usr/local/lib/python2.7/dist-packages/timesketch
+master = true
+reaper = true
+processes = 4
+buffer-size = 65535
+enable-threads = true
+
+# Settings to deal with the subdirectory
+manage-script-name = true
+static_url = /timesketch
+mount = /timesketch=timesketch.wsgi:application
+socket = /var/timesketch/timesketch.sock
+chmod-socket = 777
+vacuum = true
+die-on-term = true


### PR DESCRIPTION
This PR is to switch the Flask app controller from Gunicorn to uWSGI. This is being done in order to support subpaths for TimeSketch.